### PR TITLE
ETL Pipeline

### DIFF
--- a/src/data_processing/data_processing.py
+++ b/src/data_processing/data_processing.py
@@ -9,7 +9,8 @@ TICKERS = {
     "KOSPI": "^KS11",
     "TAIEX": "^TWII",
    # "PSEI": "^PSEI",
-    "STOXX600": "^STOXX"
+    "STOXX600": "^STOXX",
+    "NIKKEI225": "^N225"
 }
 
 # Output folder
@@ -157,6 +158,8 @@ csv_paths = {
     "TAIEX": "data/indices/TAIEX_20yr_daily.csv",
     #"PSEI": "data/indices/PSEI_20yr_daily.csv",
     "STOXX600": "data/indices/STOXX600_20yr_daily.csv",
+    "NIKKEI225": "data/indices/NIKKEI225_20yr_daily.csv",
+
 }
 
 def main():

--- a/src/data_processing/data_processing.py
+++ b/src/data_processing/data_processing.py
@@ -1,7 +1,7 @@
 import yfinance as yf
 import pandas as pd
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 
 # Index tickers
 TICKERS = {
@@ -16,7 +16,7 @@ TICKERS = {
 OUTPUT_DIR = Path("data/indices")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-# --- Last 20 years ---
+# --- Timespan of collected data ---
 end_date = datetime.today()
 start_date = "2005-01-01"
 
@@ -174,7 +174,6 @@ def main():
         print(f"Saved: {out_path}")
 
 if __name__ == "__main__":
-    print(">>> data_processing.py loaded")
     main()
 
 

--- a/src/data_processing/data_processing.py
+++ b/src/data_processing/data_processing.py
@@ -1,0 +1,180 @@
+import yfinance as yf
+import pandas as pd
+from pathlib import Path
+from datetime import datetime, timedelta
+
+# Index tickers
+TICKERS = {
+    "CSI300": "000300.SS",
+    "KOSPI": "^KS11",
+    "TAIEX": "^TWII",
+   # "PSEI": "^PSEI",
+    "STOXX600": "^STOXX"
+}
+
+# Output folder
+OUTPUT_DIR = Path("data/indices")
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# --- Last 20 years ---
+end_date = datetime.today()
+start_date = "2005-01-01"
+
+
+def download_index(ticker, start, end):
+    """Download daily index data."""
+    return yf.download(
+        ticker,
+        start=start,
+        end=end,
+        interval="1d",
+        progress=False
+    )
+
+def load_data():
+    for name, ticker in TICKERS.items():
+        print(f"Downloading {name} ({ticker})...")
+        df = download_index(ticker, start_date, end_date)
+
+        # Add index name column for clarity
+        df["Index"] = name
+
+        # Save as individual CSV (write index as a "Date" column)
+        file_path = OUTPUT_DIR / f"{name}_20yr_daily.csv"
+        df.reset_index().to_csv(file_path, index=False)
+        print(f"Saved {file_path}")
+
+    print("All downloads complete.")
+
+
+def build_clean_datasets(csv_paths):
+    """
+    csv_paths: dict like
+        {
+            "CSI300": "data/indices/CSI300_20yr_daily.csv",
+            "KOSPI": "data/indices/KOSPI_20yr_daily.csv",
+            ...
+        }
+
+    Returns:
+        dict: {name: DataFrame_with_features}
+    """
+
+    # 1) Load all price series, one per index
+    price_series = {}  # {name: Series of prices}
+
+    print("\n--- Loading raw CSVs and extracting price columns ---")
+    for name, path in csv_paths.items():
+        df = pd.read_csv(path, parse_dates=["Date"])
+        df = df.set_index("Date")
+        df = df.sort_index()
+        df = df[~df.index.duplicated(keep="last")]  # drop duplicate dates
+
+        if df.empty:
+            print(f"WARNING: {name} ({path}) is EMPTY!")
+            continue
+
+        # choose price series: prefer Adj Close, fallback to Close
+        # Coerce to numeric to avoid strings causing arithmetic errors
+        if "Adj Close" in df.columns:
+            s = pd.to_numeric(df["Adj Close"], errors="coerce").rename(name)
+        else:
+            s = pd.to_numeric(df["Close"], errors="coerce").rename(name)
+
+        # If the entire series is non-numeric after coercion, skip it
+        if s.dropna().empty:
+            print(f"WARNING: {name} has no numeric price data after coercion, skipping.")
+            continue
+
+        print(f"{name}: shape = {df.shape}, dates {df.index.min()} -> {df.index.max()}")
+        price_series[name] = s
+
+    # If any are missing, that will reduce the common date set
+    if len(price_series) == 0:
+        raise ValueError("No non-empty indices loaded. Check your downloads/tickers.")
+
+    # 2) Combine into one DataFrame of prices, keeping only dates
+    #    where ALL indices have data (inner join on index)
+    prices = pd.concat(price_series.values(), axis=1, join="inner")
+    prices = prices.sort_index()
+
+    # Drop rows with any NaN so all remaining rows are numeric for every index.
+    # This prevents pct_change and other numeric ops from encountering strings/NaNs.
+    before_rows = len(prices)
+    prices = prices.dropna(how="any")
+    after_rows = len(prices)
+    if after_rows != before_rows:
+        print(f"Dropped {before_rows - after_rows} rows with missing/non-numeric prices. New shape: {prices.shape}")
+
+    print(f"\nCombined price table shape: {prices.shape}")
+    print(f"Common dates: {prices.index.min()} -> {prices.index.max()}")
+
+    if prices.empty:
+        raise ValueError(
+            "No common dates across all indices. "
+            "Check that all CSVs cover overlapping time periods."
+        )
+
+    # 3) For each index (each column), build a feature DataFrame
+    result = {}
+
+    for name in prices.columns:
+        price = prices[name]
+
+        # daily returns
+        returns = price.pct_change()
+
+        # build feature DataFrame
+        feat = pd.DataFrame(index=prices.index)
+
+        feat["Return_t"] = returns
+
+        # lagged returns
+        feat["Return_t_1"] = returns.shift(1)
+        feat["Return_t_2"] = returns.shift(2)
+        feat["Return_t_3"] = returns.shift(3)
+
+        # moving averages of returns (using full windows)
+        feat["SMA_5"] = returns.rolling(window=5).mean()
+        feat["SMA_10"] = returns.rolling(window=10).mean()
+
+        # rolling std of returns
+        feat["STD_5"] = returns.rolling(window=5).std()
+
+        # Drop rows where any feature is NaN (initial window rows)
+        feat = feat.dropna()
+
+        print(f"{name}: feature df shape = {feat.shape}")
+        result[name] = feat
+
+    return result
+
+
+
+csv_paths = {
+    "CSI300": "data/indices/CSI300_20yr_daily.csv",
+    "KOSPI": "data/indices/KOSPI_20yr_daily.csv",
+    "TAIEX": "data/indices/TAIEX_20yr_daily.csv",
+    #"PSEI": "data/indices/PSEI_20yr_daily.csv",
+    "STOXX600": "data/indices/STOXX600_20yr_daily.csv",
+}
+
+def main():
+    load_data()
+
+    datasets = build_clean_datasets(csv_paths)
+
+    out_dir = Path("data/clean_features")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save each DataFrame
+    for name, df in datasets.items():
+        out_path = out_dir / f"{name}_features.csv"
+        df.reset_index().to_csv(out_path, index=False)
+        print(f"Saved: {out_path}")
+
+if __name__ == "__main__":
+    print(">>> data_processing.py loaded")
+    main()
+
+

--- a/src/data_processing/data_processing.py
+++ b/src/data_processing/data_processing.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 # Index tickers
 TICKERS = {
-    "CSI300": "000300.SS",
+    "SSE": "000001.SS",
     "KOSPI": "^KS11",
     "TAIEX": "^TWII",
    # "PSEI": "^PSEI",
@@ -152,7 +152,7 @@ def build_clean_datasets(csv_paths):
 
 
 csv_paths = {
-    "CSI300": "data/indices/CSI300_20yr_daily.csv",
+    "SSE": "data/indices/SSE_20yr_daily.csv",
     "KOSPI": "data/indices/KOSPI_20yr_daily.csv",
     "TAIEX": "data/indices/TAIEX_20yr_daily.csv",
     #"PSEI": "data/indices/PSEI_20yr_daily.csv",

--- a/src/data_processing/data_visualization.py
+++ b/src/data_processing/data_visualization.py
@@ -11,6 +11,8 @@ csv_paths = {
     "KOSPI": csv_dir / "KOSPI_features.csv",
     "TAIEX": csv_dir / "TAIEX_features.csv",
     "STOXX600": csv_dir / "STOXX600_features.csv",
+    "NIKKEI225": csv_dir / "NIKKEI225_features.csv",
+
 }
 
 # Output folder for images

--- a/src/data_processing/data_visualization.py
+++ b/src/data_processing/data_visualization.py
@@ -4,19 +4,26 @@ import matplotlib.ticker as mtick
 from pathlib import Path
 
 
+# Use pathlib for OS-independent paths and verify files exist before reading
+csv_dir = Path("data") / "clean_features"
 csv_paths = {
-    "SSE": "data\clean_features\SSE_features.csv",
-    "KOSPI": "data\clean_features\KOSPI_features.csv",
-    "TAIEX": "data\clean_features\TAIEX_features.csv",
-    "STOXX600": "data\clean_features\STOXX600_features.csv",
+    "SSE": csv_dir / "SSE_features.csv",
+    "KOSPI": csv_dir / "KOSPI_features.csv",
+    "TAIEX": csv_dir / "TAIEX_features.csv",
+    "STOXX600": csv_dir / "STOXX600_features.csv",
 }
 
 # Output folder for images
-img_dir = Path("data/img")
+img_dir = Path("data") / "img"
 img_dir.mkdir(parents=True, exist_ok=True)  # <-- ensure output folder exists
 
 def plot_data_daily():
     for name, path in csv_paths.items():
+        path = Path(path)
+        if not path.exists():
+            print(f"Warning: file not found, skipping {name}: {path}")
+            continue
+
         df = pd.read_csv(path, parse_dates=["Date"])
         df = df.set_index("Date")
 
@@ -50,6 +57,11 @@ def plot_all_in_one_daily():
     plt.figure(figsize=(14, 7), dpi=200)
 
     for name, path in csv_paths.items():
+        path = Path(path)
+        if not path.exists():
+            print(f"Warning: file not found, skipping {name}: {path}")
+            continue
+
         df = pd.read_csv(path, parse_dates=["Date"])
         df = df.set_index("Date")
 
@@ -72,6 +84,11 @@ def plot_all_in_one_daily():
 
 def plot_data_yearly():
     for name, path in csv_paths.items():
+        path = Path(path)
+        if not path.exists():
+            print(f"Warning: file not found, skipping {name}: {path}")
+            continue
+
         df = pd.read_csv(path, parse_dates=["Date"])
         df = df.set_index("Date")
 
@@ -116,6 +133,11 @@ def plot_all_in_one_yearly():
     plt.figure(figsize=(14, 7), dpi=200)
 
     for name, path in csv_paths.items():
+        path = Path(path)
+        if not path.exists():
+            print(f"Warning: file not found, skipping {name}: {path}")
+            continue
+
         df = pd.read_csv(path, parse_dates=["Date"])
         df = df.set_index("Date")
 

--- a/src/data_processing/data_visualization.py
+++ b/src/data_processing/data_visualization.py
@@ -1,0 +1,137 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+
+csv_paths = {
+    "SSE": "data\clean_features\SSE_features.csv",
+    "KOSPI": "data\clean_features\KOSPI_features.csv",
+    "TAIEX": "data\clean_features\TAIEX_features.csv",
+    "STOXX600": "data\clean_features\STOXX600_features.csv",
+}
+
+# Output folder for images
+img_dir = Path("data/img")
+
+def plot_data_daily():
+    for name, path in csv_paths.items():
+        df = pd.read_csv(path, parse_dates=["Date"])
+        df = df.set_index("Date")
+
+        fig, ax1 = plt.subplots(figsize=(12, 6))
+
+        # Plot Return_t
+        ax1.plot(df.index, df["Return_t"], color="blue", label="Return_t")
+        ax1.set_xlabel("Date")
+        ax1.set_ylabel("Return_t", color="blue")
+        ax1.tick_params(axis="y", labelcolor="blue")
+
+        # Second y-axis for STD_5
+        ax2 = ax1.twinx()
+        ax2.plot(df.index, df["STD_5"], color="red", label="STD_5")
+        ax2.set_ylabel("STD_5", color="red")
+        ax2.tick_params(axis="y", labelcolor="red")
+
+        plt.title(f"{name} — Return_t & STD_5 over time")
+        fig.tight_layout()
+
+        # Save figure
+        out_path = img_dir / f"{name}_return_std.png"
+        fig.savefig(out_path, dpi=300)
+        plt.close(fig)
+
+        print(f"Saved plot for {name} at {out_path}")
+
+def plot_all_in_one_daily():
+    plt.figure(figsize=(14, 7), dpi=200)
+
+    for name, path in csv_paths.items():
+        df = pd.read_csv(path, parse_dates=["Date"])
+        df = df.set_index("Date")
+
+        # Plot Return_t for each index
+        plt.plot(df.index, df["Return_t"], label=name)
+
+    plt.xlabel("Date")
+    plt.ylabel("Return_t")
+    plt.title("Return_t over time — all indices")
+    plt.legend()
+    plt.tight_layout()
+
+    out_path = img_dir / "all_indices_return.png"
+    plt.savefig(out_path)
+    plt.close()
+
+    print(f"Saved combined plot to {out_path}")
+
+def plot_data_yearly():
+    for name, path in csv_paths.items():
+        df = pd.read_csv(path, parse_dates=["Date"])
+        df = df.set_index("Date")
+
+        # --- Compute yearly performance & volatility ---
+        # We assume Return_t is daily return, e.g. pct_change-based
+        # 1) Compute cumulative annual return
+        yearly_return = (1 + df["Return_t"]).resample("Y").prod() - 1
+
+        # 2) Compute annualized volatility (std of returns * sqrt(252))
+        yearly_vol = df["Return_t"].resample("Y").std() * (252 ** 0.5)
+
+        # Combine into one DataFrame for plotting
+        yearly_df = pd.DataFrame({
+            "Return": yearly_return,
+            "Volatility": yearly_vol
+        })
+
+        # --- Plot ---
+        fig, ax1 = plt.subplots(figsize=(10, 5))
+
+        ax1.plot(yearly_df.index.year, yearly_df["Return"], label="Annual Return", marker="o")
+        ax1.set_xlabel("Year")
+        ax1.set_ylabel("Return", color="blue")
+        ax1.tick_params(axis="y", labelcolor="blue")
+
+        ax2 = ax1.twinx()
+        ax2.bar(yearly_df.index.year, yearly_df["Volatility"], alpha=0.3, color="gray", label="Annual Volatility")
+        ax2.set_ylabel("Volatility (annualized)", color="gray")
+        ax2.tick_params(axis="y", labelcolor="gray")
+
+        plt.title(f"{name} — Yearly Return & Volatility")
+        fig.tight_layout()
+
+        # Save
+        fig.savefig(img_dir / f"{name}_yearly.png", dpi=300)
+        plt.close()
+        print(f"Saved yearly plot for {name}")
+
+def plot_all_in_one_yearly():
+    plt.figure(figsize=(14, 7), dpi=200)
+
+    for name, path in csv_paths.items():
+        df = pd.read_csv(path, parse_dates=["Date"])
+        df = df.set_index("Date")
+
+        # compute yearly return: compound daily returns within each year
+        yearly_return = (1 + df["Return_t"]).resample("Y").prod() - 1
+
+        plt.plot(yearly_return.index.year, yearly_return.values, label=name)
+
+    plt.xlabel("Year")
+    plt.ylabel("Annual Return")
+    plt.title("Annual Return by Index")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+
+    out_path = img_dir / "all_indices_annual_return.png"
+    plt.savefig(out_path)
+    plt.close()
+    print("Saved combined plot to", out_path)
+
+
+if __name__ == "__main__":
+    plot_data_daily()
+    plot_all_in_one_daily()
+    plot_data_yearly()
+    plot_all_in_one_yearly()
+

--- a/src/data_processing/data_visualization.py
+++ b/src/data_processing/data_visualization.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
 from pathlib import Path
 
 
@@ -12,6 +13,7 @@ csv_paths = {
 
 # Output folder for images
 img_dir = Path("data/img")
+img_dir.mkdir(parents=True, exist_ok=True)  # <-- ensure output folder exists
 
 def plot_data_daily():
     for name, path in csv_paths.items():
@@ -24,12 +26,14 @@ def plot_data_daily():
         ax1.plot(df.index, df["Return_t"], color="blue", label="Return_t")
         ax1.set_xlabel("Date")
         ax1.set_ylabel("Return_t", color="blue")
+        ax1.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1))  # <-- als %
         ax1.tick_params(axis="y", labelcolor="blue")
 
         # Second y-axis for STD_5
         ax2 = ax1.twinx()
         ax2.plot(df.index, df["STD_5"], color="red", label="STD_5")
         ax2.set_ylabel("STD_5", color="red")
+        ax2.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1))  # <-- als %
         ax2.tick_params(axis="y", labelcolor="red")
 
         plt.title(f"{name} — Return_t & STD_5 over time")
@@ -54,6 +58,8 @@ def plot_all_in_one_daily():
 
     plt.xlabel("Date")
     plt.ylabel("Return_t")
+    ax = plt.gca()
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1))  # <-- als %
     plt.title("Return_t over time — all indices")
     plt.legend()
     plt.tight_layout()
@@ -89,11 +95,13 @@ def plot_data_yearly():
         ax1.plot(yearly_df.index.year, yearly_df["Return"], label="Annual Return", marker="o")
         ax1.set_xlabel("Year")
         ax1.set_ylabel("Return", color="blue")
+        ax1.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1))  # <-- als %
         ax1.tick_params(axis="y", labelcolor="blue")
 
         ax2 = ax1.twinx()
         ax2.bar(yearly_df.index.year, yearly_df["Volatility"], alpha=0.3, color="gray", label="Annual Volatility")
         ax2.set_ylabel("Volatility (annualized)", color="gray")
+        ax2.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1))  # <-- als %
         ax2.tick_params(axis="y", labelcolor="gray")
 
         plt.title(f"{name} — Yearly Return & Volatility")
@@ -118,6 +126,8 @@ def plot_all_in_one_yearly():
 
     plt.xlabel("Year")
     plt.ylabel("Annual Return")
+    ax = plt.gca()
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1))  # <-- als %
     plt.title("Annual Return by Index")
     plt.legend()
     plt.grid(True)
@@ -128,10 +138,11 @@ def plot_all_in_one_yearly():
     plt.close()
     print("Saved combined plot to", out_path)
 
-
-if __name__ == "__main__":
+def main():
     plot_data_daily()
     plot_all_in_one_daily()
     plot_data_yearly()
     plot_all_in_one_yearly()
 
+if __name__ == "__main__":
+    main()

--- a/src/data_processing/etl_pipeline.py
+++ b/src/data_processing/etl_pipeline.py
@@ -1,0 +1,6 @@
+import data_processing
+import data_visualization
+
+if __name__ == "__main__":
+    data_processing.main()
+    data_visualization.main()


### PR DESCRIPTION
This PR adds the following functionality:

- downloads indice data for the following indices from 2005 to 2025: KOSPI, SSE, TAIEX, STOXX 600, NIKKEI225
- cleans the data and enriches it with the needed features for model training (see google docs)
- saves the cleaned and enriched data in seperate csv files
- visualizes the data in the following format:
- two plots for each csv (one daily and one yearly)
- two plots which plot the performance of every indice in one single graph

To run the etl pipeline use the following command in your powershell/bash:
```
python .\etl_pipeline.py
```

Folder structure:
<img width="372" height="537" alt="image" src="https://github.com/user-attachments/assets/b3c2d308-ced5-4f06-9ce3-8c327c70c677" />
